### PR TITLE
Fix resizableContainer init bug

### DIFF
--- a/js/canvas-manager.js
+++ b/js/canvas-manager.js
@@ -135,15 +135,14 @@ function resizeCanvasToObject(objectWidth, objectHeight) {
 
 }
 
-var resizableContainer = 0;
+var resizableContainer = null;
 
 document.addEventListener('DOMContentLoaded', function() {
+  resizableContainer = $('canvas-container');
+
   $('bg-color').addEventListener('input', function (event) {
     var color = event.target.value;
     canvas.setBackgroundColor(color, canvas.renderAll.bind(canvas));
-  });
-  $('bg-color').addEventListener('input', function (event) {
-    resizableContainer = $('canvas-container');
   });
 });
 


### PR DESCRIPTION
## Summary
- initialize `resizableContainer` on page load instead of waiting for a color change
- drop redundant event handler that set the variable

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_683f6d3a79f08331ba7efaa2101771d3