### PR TITLE
Add unit test for SvgBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ git clone https://github.com/new-sankaku/stable-diffusion-webui-simple-manga-mak
 
 <img src="https://new-sankaku.github.io/SP-MangaEditer-docs/02_.webp" width="700">
 
+## Running Tests
+
+Run the unit tests with:
+
+```bash
+python -m unittest
+```
+
 ## How to Contribute
 - **Bug Reports**: Create a new issue with **[Bug]** in the title
 - **Feature Requests**: Create a new issue with **[Feature Request]** in the title

--- a/tests/test_svg_builder.py
+++ b/tests/test_svg_builder.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import tempfile
+import unittest
+
+# Adjust path to import SvgBuilder
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '01_build'))
+
+from SvgBuilder import generate_js_svg_array
+
+class TestSvgBuilder(unittest.TestCase):
+    def test_generate_js_svg_array(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            svg_dir = os.path.join(tmpdir, 'svg')
+            os.makedirs(svg_dir)
+            sample_svg_path = os.path.join(svg_dir, 'sample.svg')
+            with open(sample_svg_path, 'w', encoding='utf-8') as f:
+                f.write('<svg><rect width="10" height="10"/></svg>')
+
+            output_js = os.path.join(tmpdir, 'output.js')
+            generate_js_svg_array(svg_dir, output_js, 'testArray')
+
+            self.assertTrue(os.path.exists(output_js), 'JS output file not created')
+            with open(output_js, 'r', encoding='utf-8') as f:
+                content = f.read()
+            self.assertIn('name: "sample"', content)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create a `tests/` package with `test_svg_builder.py`
- document how to run the tests with `python -m unittest`

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_683f7234c30c83319c1c8187dbeb59f2