### PR TITLE
Fix repository name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ You can either use the demo site or add it as an extension to WebUI. It runs in 
 
 All features are available through the demo site alone.
 
-[Web Site: Desu!](https://new-sankaku.github.io/SP-MangaEditer/)
+[Web Site: Desu!](https://new-sankaku.github.io/SP-MangaEditor/)
 
 If you prefer to download files locally instead of using the extension (faster method):
 
-git clone https://github.com/new-sankaku/SP-MangaEditer.git
-cd SP-MangaEditer
+git clone https://github.com/new-sankaku/SP-MangaEditor.git
+cd SP-MangaEditor
 start index.html
 
 The application supports various features including image drag-and-drop, file selection import, Text2Image functionality, and Image2Image capabilities. It comes with pre-built panel layouts for beginners to easily create manga, as well as a professional knife tool for custom panel cutting. The features continue to evolve, and regular updates are recommended.
@@ -30,7 +30,7 @@ The application supports various features including image drag-and-drop, file se
 ## Interface Previews
 
 ### Main Page
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/01_mainpage.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/01_mainpage.webp" width="700">
 
 ### Image Drop
 https://github.com/user-attachments/assets/7cf94e6c-fc39-4aed-a0a1-37ca70260fe4
@@ -39,44 +39,44 @@ https://github.com/user-attachments/assets/7cf94e6c-fc39-4aed-a0a1-37ca70260fe4
 https://github.com/user-attachments/assets/6f1dae5f-b50f-4b04-8875-f0b07111f2ab
 
 ### Image Prompt Helper
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/03_prompthelper.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/03_prompthelper.webp" width="700">
 
 ### Language Support
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/02_trans.webp" height="400">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/02_trans.webp" height="400">
 
 ### Grid Line / Knife Mode
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/05_gridline.webp" height="350">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/06_knifemode.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/05_gridline.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/06_knifemode.webp" height="350">
 </div>
 
 ### Dark Mode / Light Mode
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/09_darkmode.webp" height="350">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/09_lightmode.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/09_darkmode.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/09_lightmode.webp" height="350">
 </div>
 
 ### Blend Mode and Samples
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/11_blendmode.webp" height="800">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/11_blendmode.webp" height="800">
 
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/12_blend.webp" height="350">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/13_blend.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/12_blend.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/13_blend.webp" height="350">
 </div>
 
 ### Drag and Drop
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/14_Drag on drop.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/14_Drag on drop.webp" width="700">
 
 ### Effects
 <div style="display: flex; align-items: flex-start;">
-    <img src="https://new-sankaku.github.io/SP-MangaEditer-docs/04_gpix01.webp" width="400">
-    <img src="https://new-sankaku.github.io/SP-MangaEditer-docs/04_gpix02.webp" width="400">
+    <img src="https://new-sankaku.github.io/SP-MangaEditor-docs/04_gpix01.webp" width="400">
+    <img src="https://new-sankaku.github.io/SP-MangaEditor-docs/04_gpix02.webp" width="400">
 </div>
 
 ### Text, Speech Bubbles, Pen
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/08_speechbubble.webp" width="400">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/07_font.webp" width="400">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/08_speechbubble.webp" width="400">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/07_font.webp" width="400">
 </div>
 
 ## Features
@@ -123,7 +123,7 @@ https://github.com/user-attachments/assets/6f1dae5f-b50f-4b04-8875-f0b07111f2ab
 
 git clone https://github.com/new-sankaku/stable-diffusion-webui-simple-manga-maker.git
 
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/02_.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/02_.webp" width="700">
 
 ## How to Contribute
 - **Bug Reports**: Create a new issue with **[Bug]** in the title

--- a/README_CN.md
+++ b/README_CN.md
@@ -12,12 +12,12 @@
 
 所有功能都可以通过演示网站使用。
 
-[网站：Desu!](https://new-sankaku.github.io/SP-MangaEditer/)
+[网站：Desu!](https://new-sankaku.github.io/SP-MangaEditor/)
 
 如果您更喜欢本地下载文件而不是使用扩展程序（更快的方法）：
 
-git clone https://github.com/new-sankaku/SP-MangaEditer.git
-cd SP-MangaEditer
+git clone https://github.com/new-sankaku/SP-MangaEditor.git
+cd SP-MangaEditor
 start index.html
 
 该应用程序支持多种功能，包括图像拖放、文件选择导入、文字生成图像功能和图像转换功能。它为初学者提供预设的面板布局，便于创建漫画，同时还配备专业的切割工具，可以自定义面板切割。功能不断发展，建议定期更新。
@@ -25,7 +25,7 @@ start index.html
 ## 界面预览
 
 ### 主页面
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/01_mainpage.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/01_mainpage.webp" width="700">
 
 ### Image Drop
 https://github.com/user-attachments/assets/7cf94e6c-fc39-4aed-a0a1-37ca70260fe4
@@ -34,44 +34,44 @@ https://github.com/user-attachments/assets/7cf94e6c-fc39-4aed-a0a1-37ca70260fe4
 https://github.com/user-attachments/assets/6f1dae5f-b50f-4b04-8875-f0b07111f2ab
 
 ### 图像提示助手
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/03_prompthelper.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/03_prompthelper.webp" width="700">
 
 ### 语言支持
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/02_trans.webp" height="400">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/02_trans.webp" height="400">
 
 ### 网格线/切割模式
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/05_gridline.webp" height="350">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/06_knifemode.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/05_gridline.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/06_knifemode.webp" height="350">
 </div>
 
 ### 暗色模式/亮色模式
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/09_darkmode.webp" height="350">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/09_lightmode.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/09_darkmode.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/09_lightmode.webp" height="350">
 </div>
 
 ### 混合模式和示例
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/11_blendmode.webp" height="800">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/11_blendmode.webp" height="800">
 
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/12_blend.webp" height="350">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/13_blend.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/12_blend.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/13_blend.webp" height="350">
 </div>
 
 ### 拖放功能
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/14_Drag on drop.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/14_Drag on drop.webp" width="700">
 
 ### 特效
 <div style="display: flex; align-items: flex-start;">
-    <img src="https://new-sankaku.github.io/SP-MangaEditer-docs/04_gpix01.webp" width="400">
-    <img src="https://new-sankaku.github.io/SP-MangaEditer-docs/04_gpix02.webp" width="400">
+    <img src="https://new-sankaku.github.io/SP-MangaEditor-docs/04_gpix01.webp" width="400">
+    <img src="https://new-sankaku.github.io/SP-MangaEditor-docs/04_gpix02.webp" width="400">
 </div>
 
 ### 文字、对话气泡、笔工具
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/08_speechbubble.webp" width="400">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/07_font.webp" width="400">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/08_speechbubble.webp" width="400">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/07_font.webp" width="400">
 </div>
 
 ## 功能特点
@@ -118,7 +118,7 @@ https://github.com/user-attachments/assets/6f1dae5f-b50f-4b04-8875-f0b07111f2ab
 
 git clone https://github.com/new-sankaku/stable-diffusion-webui-simple-manga-maker.git
 
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/02_.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/02_.webp" width="700">
 
 ## 如何贡献
 - **错误报告**: 创建新问题时在标题中加入 **[Bug]**

--- a/README_JP.md
+++ b/README_JP.md
@@ -12,12 +12,12 @@ ComfyUI:SD1.5, SDXL, Pony, Flux1
 
 デモサイトのみでもすべての機能を利用できます。
 
-[Web Site:Desu!](https://new-sankaku.github.io/SP-MangaEditer/)
+[Web Site:Desu!](https://new-sankaku.github.io/SP-MangaEditor/)
 
 
 拡張機能ではなくローカル上にファイルを落としたい場合はこちらです。こっちのが早い。
-git clone https://github.com/new-sankaku/SP-MangaEditer.git
-cd SP-MangaEditer
+git clone https://github.com/new-sankaku/SP-MangaEditor.git
+cd SP-MangaEditor
 start index.html
 
 
@@ -26,7 +26,7 @@ start index.html
 また、プロ仕様のコマ割りが可能なナイフツールも備えており、自由にコマを切ることができます。機能は継続して発展し続けており、定期的なアップデートを推奨します。
 
 ## Main Page
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/01_mainpage.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/01_mainpage.webp" width="700">
 
 ### Image Drop
 https://github.com/user-attachments/assets/7cf94e6c-fc39-4aed-a0a1-37ca70260fe4
@@ -35,45 +35,45 @@ https://github.com/user-attachments/assets/7cf94e6c-fc39-4aed-a0a1-37ca70260fe4
 https://github.com/user-attachments/assets/6f1dae5f-b50f-4b04-8875-f0b07111f2ab
 
 ### Image Prompt Helper
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/03_prompthelper.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/03_prompthelper.webp" width="700">
 
 ## Support Language
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/02_trans.webp" height="400">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/02_trans.webp" height="400">
 
 ## Grid Line / Knife Mode
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/05_gridline.webp" height="350">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/06_knifemode.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/05_gridline.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/06_knifemode.webp" height="350">
 </div>
 
 ## Dark Mode / Light Mode
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/09_darkmode.webp" height="350">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/09_lightmode.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/09_darkmode.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/09_lightmode.webp" height="350">
 </div>
 
 ## Blend Mode
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/11_blendmode.webp" height="800">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/11_blendmode.webp" height="800">
 
 ## Blend Mode Sample
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/12_blend.webp" height="350">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/13_blend.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/12_blend.webp" height="350">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/13_blend.webp" height="350">
 </div>
 
 ## Drag on Drop
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/14_Drag on drop.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/14_Drag on drop.webp" width="700">
 
 ## Effect
 <div style="display: flex; align-items: flex-start;">
-    <img src="https://new-sankaku.github.io/SP-MangaEditer-docs/04_gpix01.webp" width="400">
-    <img src="https://new-sankaku.github.io/SP-MangaEditer-docs/04_gpix02.webp" width="400">
+    <img src="https://new-sankaku.github.io/SP-MangaEditor-docs/04_gpix01.webp" width="400">
+    <img src="https://new-sankaku.github.io/SP-MangaEditor-docs/04_gpix02.webp" width="400">
 </div>
 
 ## Text, Speech Bubbles, Pen
 <div style="display: flex; align-items: flex-start;">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/08_speechbubble.webp" width="400">
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/07_font.webp" width="400">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/08_speechbubble.webp" width="400">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/07_font.webp" width="400">
 </div>
 
 
@@ -110,7 +110,7 @@ https://github.com/user-attachments/assets/6f1dae5f-b50f-4b04-8875-f0b07111f2ab
 
 # インストール
 https://github.com/new-sankaku/stable-diffusion-webui-simple-manga-maker.git  
-<img src="https://new-sankaku.github.io/SP-MangaEditer-docs/02_.webp" width="700">
+<img src="https://new-sankaku.github.io/SP-MangaEditor-docs/02_.webp" width="700">
 
 ## 貢献方法
 - **バグ報告**: バグを発見した場合は、[Issues](https://github.com/new-sankaku/stable-diffusion-webui-simple-manga-maker/issues)に新しい問題を作成し、タイトルに**[Bug]**を含めてください。


### PR DESCRIPTION
## Summary
- correct the repository name from `SP-MangaEditer` to `SP-MangaEditor` in README files

## Testing
- `grep -n SP-MangaEditer -n README.md README_JP.md README_CN.md`


------
https://chatgpt.com/codex/tasks/task_e_683f72334df083319746aa500c216f9d