### PR TITLE
Fix inconsistent undo/redo for speech bubbles

### DIFF
--- a/js/sidebar/speechBubble/speech-bubble-text.js
+++ b/js/sidebar/speechBubble/speech-bubble-text.js
@@ -142,6 +142,7 @@ function updateShapeMetrics(svgObj) {
 
 function createSpeechBubbleMetrics(svgObj, svgData) {
   // console.log("createSpeechBubbleMetrics call");
+  changeDoNotSaveHistory();
 
   let grid, scale, viewBox, largestRect;
   ({ grid, scale, viewBox } = createGrid(svgData));
@@ -289,15 +290,14 @@ function createSpeechBubbleMetrics(svgObj, svgData) {
   svgObj.lastLeft = svgObj.left;
   svgObj.lastTop = svgObj.top;
 
-  changeDoNotSaveHistory();
-    // canvas.sendToBack(svgObj);
-    canvas.add(newRect);
-  changeDoSaveHistory();
-
+  // canvas.sendToBack(svgObj);
+  canvas.add(newRect);
   canvas.add(newTextbox);
-  
+
   // canvas.bringToFront(newTextbox);
   canvas.renderAll();
+  changeDoSaveHistory();
+  saveStateByManual();
 }
 
 function updateObjectPositions(svgObject, immediate = false) {


### PR DESCRIPTION
## Summary
- wrap speech bubble creation in history pause
- save state once after bubble creation

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_683f78bb8ae48331ba3c3abcbb17b86f