### PR TITLE
Fix inconsistent undo/redo for speech bubbles

### DIFF
--- a/js/core/settings.js
+++ b/js/core/settings.js
@@ -94,7 +94,7 @@ const commonProperties = [
 'name',
 "guids", "guid", "tempPrompt", "tempNegative", "tempSeed", "img2imgScale", "img2img_denoise", "canvasGuid", "isSpeechBubble","jstsGeom","text","selectable","customType"
 ,"speechBubbleGrid","speechBubbleScale","speechBubbleViewBoxWidth","speechBubbleViewBoxHeight","speechBubbleRectX","speechBubbleRectY","speechBubbleRectWidth","speechBubbleRectHeight"
-,"baseScaleX","baseScaleY","lastLeft", "lastTop", "targetObject", "originalSvg"
+,"baseScaleX","baseScaleY","lastLeft", "lastTop", "targetObject", "originalSvg", "data"
 ];
 
 let jscolorOptions = {

--- a/js/sidebar/speechBubble/speech-bubble-effect.js
+++ b/js/sidebar/speechBubble/speech-bubble-effect.js
@@ -8,7 +8,7 @@ function changeSpeechBubble() {
 
 }
 function changeSpeechBubbleSVG(bubbleStrokewidht, fillColor, strokeColor, opacity){
-    opacity = opacity / 100;  
+    opacity = opacity / 100;
     var fillColorRgba   = hexToRgba(fillColor,opacity);
     var strokeColorRgba = hexToRgba(strokeColor,1.0);
 
@@ -16,6 +16,7 @@ function changeSpeechBubbleSVG(bubbleStrokewidht, fillColor, strokeColor, opacit
 
     var activeObject = canvas.getActiveObject();
     if (activeObject) {
+        changeDoNotSaveHistory();
 
             let isExistsFillArea = false;
             if(isPath(activeObject)){
@@ -44,6 +45,8 @@ function changeSpeechBubbleSVG(bubbleStrokewidht, fillColor, strokeColor, opacit
                 });    
             }
         canvas.requestRenderAll();
+        changeDoSaveHistory();
+        saveStateByManual();
     }
 }
 
@@ -117,7 +120,17 @@ function getSpeechBubbleTextFill(activeObject, type){
 }
 
 function loadSpeechBubbleSVGReadOnly(svgString, name) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgString, "image/svg+xml");
+    const idList = Array.from(doc.querySelectorAll("path,polygon")).map(el => el.getAttribute("id"));
+
     fabric.loadSVGFromString(svgString, function (objects, options) {
+        objects.forEach((obj, idx) => {
+            if (idList[idx]) {
+                if (!obj.data) obj.data = {};
+                obj.data.originalId = idList[idx];
+            }
+        });
         
         const svgObject = fabric.util.groupSVGElements(objects, options);
 

--- a/js/sidebar/speechBubble/speech-bubble-text.js
+++ b/js/sidebar/speechBubble/speech-bubble-text.js
@@ -142,6 +142,7 @@ function updateShapeMetrics(svgObj) {
 
 function createSpeechBubbleMetrics(svgObj, svgData) {
   // console.log("createSpeechBubbleMetrics call");
+  changeDoNotSaveHistory();
 
   let grid, scale, viewBox, largestRect;
   ({ grid, scale, viewBox } = createGrid(svgData));
@@ -289,15 +290,14 @@ function createSpeechBubbleMetrics(svgObj, svgData) {
   svgObj.lastLeft = svgObj.left;
   svgObj.lastTop = svgObj.top;
 
-  changeDoNotSaveHistory();
-    // canvas.sendToBack(svgObj);
-    canvas.add(newRect);
-  changeDoSaveHistory();
-
+  // canvas.sendToBack(svgObj);
+  canvas.add(newRect);
   canvas.add(newTextbox);
-  
+
   // canvas.bringToFront(newTextbox);
   canvas.renderAll();
+  changeDoSaveHistory();
+  saveStateByManual();
 }
 
 function updateObjectPositions(svgObject, immediate = false) {


### PR DESCRIPTION
## Summary
- restore history state after bubble editing without active object
- persist speech bubble path IDs for undo

## Testing
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_683f78bb8ae48331ba3c3abcbb17b86f