### PR TITLE
Fix panel click interference

### DIFF
--- a/js/sidebar/panel/panel-manager.js
+++ b/js/sidebar/panel/panel-manager.js
@@ -366,6 +366,7 @@ function loadSVGPlusReset(svgString, isLand=false) {
           stroke: obj.stroke,
           strokeWidth: strokeWidth,
           selectable: false,
+          evented: false,
           hasControls: true,
           lockMovementX: false,
           lockMovementY: false,
@@ -405,6 +406,7 @@ function loadSVGPlusReset(svgString, isLand=false) {
         obj.objectCaching = false;
         canvas.add(obj);
         obj.selectable = false;
+        obj.evented = false;
       }
     });
 

--- a/js/sidebar/panel/panel-template.js
+++ b/js/sidebar/panel/panel-template.js
@@ -258,6 +258,7 @@ function addSquareBySize(width, height) {
   canvas.add(square);
 
   square.selectable = false;
+  square.evented = false;
   updateLayerPanel();
 }
 


### PR DESCRIPTION
## Summary
- prevent panel shapes from intercepting pointer events
- update panel template for same behavior

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842424aac3083319727ed69e569d2a3