### PR TITLE
Fix panel selection when empty

### DIFF
--- a/js/core/util/fabric-util.js
+++ b/js/core/util/fabric-util.js
@@ -212,6 +212,10 @@ function setGUID(personObject, childObject) {
   guid = getGUID(childObject);
   // console.log(personObject.name + " : setGUID", guid);
   personObject.guids.push(guid);
+  if (personObject.guids.length > 0) {
+    personObject.selectable = false;
+    personObject.evented = false;
+  }
 }
 
 function removeGUID(personObject, childObject) {
@@ -231,6 +235,10 @@ function removeGUID(personObject, childObject) {
   
   if (index !== -1) {
     personObject.guids.splice(index, 1);
+  }
+  if (personObject.guids.length === 0) {
+    personObject.selectable = true;
+    personObject.evented = true;
   }
   updateLayerPanel();
 }

--- a/js/sidebar/panel/panel-manager.js
+++ b/js/sidebar/panel/panel-manager.js
@@ -365,7 +365,8 @@ function loadSVGPlusReset(svgString, isLand=false) {
           left: obj.left * scaleToFit + offsetX,
           stroke: obj.stroke,
           strokeWidth: strokeWidth,
-          selectable: false,
+          selectable: true,
+          evented: true,
           hasControls: true,
           lockMovementX: false,
           lockMovementY: false,
@@ -404,7 +405,8 @@ function loadSVGPlusReset(svgString, isLand=false) {
         obj.lockScalingY = false;
         obj.objectCaching = false;
         canvas.add(obj);
-        obj.selectable = false;
+        obj.selectable = true;
+        obj.evented = true;
       }
     });
 

--- a/js/sidebar/panel/panel-template.js
+++ b/js/sidebar/panel/panel-template.js
@@ -257,7 +257,8 @@ function addSquareBySize(width, height) {
   setPanelValue(square);
   canvas.add(square);
 
-  square.selectable = false;
+  square.selectable = true;
+  square.evented = true;
   updateLayerPanel();
 }
 


### PR DESCRIPTION
## Summary
- allow panels to be clicked when no image is inside
- turn off panel interactivity once an image is added
- restore interactivity when all images are removed

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842424aac3083319727ed69e569d2a3